### PR TITLE
[probe] Fix ICMP timeout

### DIFF
--- a/src/probe/poll.rs
+++ b/src/probe/poll.rs
@@ -172,7 +172,7 @@ fn proceed_replica_request_icmp(host: &str) -> (bool, Option<Duration>) {
                 //   timeout value is used by default, though the configured dead delay value \
                 //   is preferred in the event it is lower than the hard-coded value (unlikely \
                 //   though possible in some setups).
-                let pinger_timeout = Duration::from_secs(min(
+                let pinger_timeout = Duration::from_millis(min(
                     NODE_ICMP_TIMEOUT_MILLISECONDS,
                     acquire_dead_timeout().as_secs() * 1000,
                 ));


### PR DESCRIPTION
I noticed that pinging my dead node took ~15 minutes; it turned out that the timeout resolves to 1000 seconds instead of milliseconds.